### PR TITLE
Resolved issue with empty array initial value;

### DIFF
--- a/projects/form-control-change-tracker/src/lib/utils/comparer.ts
+++ b/projects/form-control-change-tracker/src/lib/utils/comparer.ts
@@ -6,6 +6,9 @@ function hasNoChanges(diff: Diff<any, any>[] | undefined) {
 
 export function comparer(initialValue: any, currentValue: any): boolean {
   if (Array.isArray(initialValue)) {
+    if (!initialValue.length && Array.isArray(currentValue) && !currentValue.length) {
+      return true;
+    }
     for (let i = 0; i < initialValue.length; i++) {
       const currentInitialValue = initialValue[i];
       const differences = diff(currentInitialValue, currentValue);


### PR DESCRIPTION
There is an issue when both the initial value and the current value are empty arrays.
The check would to try to iterate over the initial values, looking for a matching value and would return `false` if none was found. But when the initial value is `[]`, this would by default return `false`.